### PR TITLE
run tests in parallel

### DIFF
--- a/internal/tui/handlers/common.go
+++ b/internal/tui/handlers/common.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"fmt"
-	"sync"
 
 	"github.com/gdamore/tcell/v2"
 	"github.com/kampanosg/lazytest/internal/tui/elements"
@@ -36,12 +35,9 @@ func runTest(
 	a *tview.Application,
 	e *elements.Elements,
 	s *state.State,
-	wg *sync.WaitGroup,
 	testNode *tview.TreeNode,
 	test *models.LazyTest,
 ) {
-	defer wg.Done()
-
 	a.QueueUpdateDraw(func() {
 		testNode.SetText(fmt.Sprintf("[yellow] [darkturquoise]%s", test.Name))
 		e.Output.SetBorderColor(tcell.ColorYellow)

--- a/internal/tui/handlers/run.go
+++ b/internal/tui/handlers/run.go
@@ -32,15 +32,12 @@ func HandleRun(r runner, a *tview.Application, e *elements.Elements, s *state.St
 	switch ref.(type) {
 	case *models.LazyTestSuite:
 		for _, child := range testNode.GetChildren() {
-			wg.Add(1)
 			test := child.GetReference().(*models.LazyTest)
-			runTest(r, a, e, s, &wg, child, test)
+			runTest(r, a, e, s, child, test)
 		}
-		wg.Wait()
 		HandleNodeChanged(e, s)(testNode)
 	case *models.LazyTest:
-		wg.Add(1)
-		runTest(r, a, e, s, &wg, testNode, ref.(*models.LazyTest))
+		go runTest(r, a, e, s,  testNode, ref.(*models.LazyTest))
 		wg.Wait()
 	}
 

--- a/internal/tui/handlers/run.go
+++ b/internal/tui/handlers/run.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"fmt"
-	"sync"
 
 	"github.com/kampanosg/lazytest/internal/tui/elements"
 	"github.com/kampanosg/lazytest/internal/tui/state"
@@ -21,7 +20,6 @@ func HandleRun(r runner, a *tview.Application, e *elements.Elements, s *state.St
 		return
 	}
 
-	var wg sync.WaitGroup
 	s.Reset()
 
 	a.QueueUpdateDraw(func() {
@@ -29,16 +27,15 @@ func HandleRun(r runner, a *tview.Application, e *elements.Elements, s *state.St
 		e.InfoBox.SetText(fmt.Sprintf("Running %s", testNode.GetText()))
 	})
 
-	switch ref.(type) {
+	switch v := ref.(type) {
 	case *models.LazyTestSuite:
 		for _, child := range testNode.GetChildren() {
 			test := child.GetReference().(*models.LazyTest)
-			runTest(r, a, e, s, child, test)
+			go runTest(r, a, e, s, child, test)
 		}
 		HandleNodeChanged(e, s)(testNode)
 	case *models.LazyTest:
-		go runTest(r, a, e, s,  testNode, ref.(*models.LazyTest))
-		wg.Wait()
+		go runTest(r, a, e, s, testNode, v)
 	}
 
 	updateRunInfo(a, e, s)

--- a/internal/tui/handlers/run_all.go
+++ b/internal/tui/handlers/run_all.go
@@ -1,6 +1,9 @@
 package handlers
 
 import (
+	"fmt"
+
+	tcell "github.com/gdamore/tcell/v2"
 	"github.com/kampanosg/lazytest/internal/tui/elements"
 	"github.com/kampanosg/lazytest/internal/tui/state"
 	"github.com/kampanosg/lazytest/pkg/models"
@@ -36,9 +39,32 @@ func doRunAll(
 				continue
 			}
 
-			switch ref.(type) {
+			switch ref := ref.(type) {
 			case *models.LazyTest:
-				go runTest(r, a, e, s, testNode, ref.(*models.LazyTest))
+				go func() {
+					a.QueueUpdateDraw(func() {
+						testNode.SetText(fmt.Sprintf("[yellow] [darkturquoise]%s", ref.Name))
+						e.Output.SetBorderColor(tcell.ColorYellow)
+					})
+					res := r.Run(ref.RunCmd)
+					if res.IsSuccess {
+						a.QueueUpdateDraw(func() {
+							e.Output.SetBorderColor(tcell.ColorGreen)
+							testNode.SetText(fmt.Sprintf("[limegreen] [darkturquoise]%s", ref.Name))
+						})
+						s.PassedTests = append(s.PassedTests, testNode)
+					} else {
+						a.QueueUpdateDraw(func() {
+							e.Output.SetBorderColor(tcell.ColorOrangeRed)
+							testNode.SetText(fmt.Sprintf("[orangered] [darkturquoise]%s", ref.Name))
+						})
+						s.FailedTests = append(s.FailedTests, testNode)
+					}
+					a.QueueUpdateDraw(func() {
+						e.Output.SetText(res.Output)
+					})
+					s.TestOutput[testNode] = res
+				}()
 			}
 		}
 	}

--- a/internal/tui/handlers/run_failed.go
+++ b/internal/tui/handlers/run_failed.go
@@ -1,8 +1,6 @@
 package handlers
 
 import (
-	"sync"
-
 	"github.com/kampanosg/lazytest/internal/tui/elements"
 	"github.com/kampanosg/lazytest/internal/tui/state"
 	"github.com/kampanosg/lazytest/pkg/models"
@@ -17,8 +15,6 @@ func HandleRunFailed(r runner, a *tview.Application, e *elements.Elements, s *st
 		return
 	}
 
-	var wg sync.WaitGroup
-
 	failedTests := s.FailedTests
 	s.Reset()
 
@@ -28,17 +24,15 @@ func HandleRunFailed(r runner, a *tview.Application, e *elements.Elements, s *st
 	})
 
 	for _, testNode := range failedTests {
-		wg.Add(1)
 		ref := testNode.GetReference()
 		if ref == nil {
 			continue
 		}
 
 		if test, ok := ref.(*models.LazyTest); ok {
-			runTest(r, a, e, s, &wg, testNode, test)
+			go runTest(r, a, e, s, testNode, test)
 		}
 	}
 
-	wg.Wait()
 	updateRunInfo(a, e, s)
 }

--- a/internal/tui/handlers/run_passed.go
+++ b/internal/tui/handlers/run_passed.go
@@ -1,8 +1,6 @@
 package handlers
 
 import (
-	"sync"
-
 	"github.com/kampanosg/lazytest/internal/tui/elements"
 	"github.com/kampanosg/lazytest/internal/tui/state"
 	"github.com/kampanosg/lazytest/pkg/models"
@@ -17,8 +15,6 @@ func HandleRunPassed(r runner, a *tview.Application, e *elements.Elements, s *st
 		return
 	}
 
-	var wg sync.WaitGroup
-
 	passedTests := s.PassedTests
 	s.Reset()
 
@@ -28,18 +24,16 @@ func HandleRunPassed(r runner, a *tview.Application, e *elements.Elements, s *st
 	})
 
 	for _, testNode := range passedTests {
-		wg.Add(1)
 		ref := testNode.GetReference()
 		if ref == nil {
 			continue
 		}
 
 		if test, ok := ref.(*models.LazyTest); ok {
-			runTest(r, a, e, s, &wg, testNode, test)
+			runTest(r, a, e, s, testNode, test)
 		}
 
 	}
 
-	wg.Wait()
 	updateRunInfo(a, e, s)
 }

--- a/internal/tui/handlers/run_passed.go
+++ b/internal/tui/handlers/run_passed.go
@@ -30,7 +30,7 @@ func HandleRunPassed(r runner, a *tview.Application, e *elements.Elements, s *st
 		}
 
 		if test, ok := ref.(*models.LazyTest); ok {
-			runTest(r, a, e, s, testNode, test)
+			go runTest(r, a, e, s, testNode, test)
 		}
 
 	}


### PR DESCRIPTION
eliminates the wait groups to make the tests run in parallel instead of sequentially