### PR TITLE
LazyTestResult - rename IsSuccess

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -20,8 +20,8 @@ func (r *Runner) Run(cmd string) *models.LazyTestResult {
 	out, err := c.Output()
 
 	return &models.LazyTestResult{
-		IsSuccess: err == nil,
-		Output:    string(out),
-		Duration:  time.Since(now),
+		Passed:   err == nil,
+		Output:   string(out),
+		Duration: time.Since(now),
 	}
 }

--- a/internal/tui/handlers/common.go
+++ b/internal/tui/handlers/common.go
@@ -49,14 +49,14 @@ func receiveTestResults(ch <-chan *runResult, a tui.Application, e *elements.Ele
 func handleTestFinished(a tui.Application, e *elements.Elements, s *state.State, testResult *runResult, hnc func(e *elements.Elements, s *state.State) func(node *tview.TreeNode)) {
 	txt := fmt.Sprintf("[orangered] [darkturquoise]%s", testResult.test.Name)
 	borderColor := tcell.ColorOrangeRed
-	if testResult.res.IsSuccess {
+	if testResult.res.Passed {
 		txt = fmt.Sprintf("[limegreen] [darkturquoise]%s", testResult.test.Name)
 		borderColor = tcell.ColorGreen
 	}
 
 	s.TestOutput[testResult.node] = testResult.res
 
-	if testResult.res.IsSuccess {
+	if testResult.res.Passed {
 		s.PassedTests = append(s.PassedTests, testResult.node)
 	} else {
 		s.FailedTests = append(s.FailedTests, testResult.node)
@@ -64,7 +64,7 @@ func handleTestFinished(a tui.Application, e *elements.Elements, s *state.State,
 
 	s.History[testResult.node] = append(s.History[testResult.node], state.HistoricalEntry{
 		Timestamp: time.Now(),
-		Passed:    testResult.res.IsSuccess,
+		Passed:    testResult.res.Passed,
 	})
 
 	s.Timings[testResult.node] = append(s.Timings[testResult.node], testResult.res.Duration)

--- a/internal/tui/handlers/node_changed.go
+++ b/internal/tui/handlers/node_changed.go
@@ -33,7 +33,7 @@ func (h *Handlers) HandleNodeChanged(e *elements.Elements, s *state.State) func(
 				res, ok := s.TestOutput[child]
 				if ok {
 					hasTestOutput = true
-					if !res.IsSuccess {
+					if !res.Passed {
 						hasFailedTest = true
 					}
 					output := fmt.Sprintf("--- %s ---\n%s\n\n", child.GetText(), res.Output)
@@ -57,7 +57,7 @@ func (h *Handlers) HandleNodeChanged(e *elements.Elements, s *state.State) func(
 			res, ok := s.TestOutput[node]
 
 			if ok {
-				if res.IsSuccess {
+				if res.Passed {
 					e.Output.SetBorderColor(tcell.ColorGreen)
 				} else {
 					e.Output.SetBorderColor(tcell.ColorOrangeRed)
@@ -116,4 +116,3 @@ func updateTimings(e *elements.Elements, s *state.State, node *tview.TreeNode) {
 		idx += 1
 	}
 }
-

--- a/internal/tui/handlers/node_changed_test.go
+++ b/internal/tui/handlers/node_changed_test.go
@@ -83,8 +83,8 @@ func TestHandleNodeChanged(t *testing.T) {
 			fields: func() fields {
 				s := state.NewState()
 				s.TestOutput[testNode1] = &models.LazyTestResult{
-					IsSuccess: true,
-					Output:    "test passed",
+					Passed: true,
+					Output: "test passed",
 				}
 
 				return fields{
@@ -106,8 +106,8 @@ func TestHandleNodeChanged(t *testing.T) {
 			fields: func() fields {
 				s := state.NewState()
 				s.TestOutput[testNode1] = &models.LazyTestResult{
-					IsSuccess: false,
-					Output:    "test failed",
+					Passed: false,
+					Output: "test failed",
 				}
 
 				return fields{
@@ -129,12 +129,12 @@ func TestHandleNodeChanged(t *testing.T) {
 			fields: func() fields {
 				s := state.NewState()
 				s.TestOutput[testNode1] = &models.LazyTestResult{
-					IsSuccess: false,
-					Output:    "test failed",
+					Passed: false,
+					Output: "test failed",
 				}
 				s.TestOutput[testNode2] = &models.LazyTestResult{
-					IsSuccess: true,
-					Output:    "test passed",
+					Passed: true,
+					Output: "test passed",
 				}
 				return fields{
 					Elems: elements.NewElements(),

--- a/pkg/models/models.go
+++ b/pkg/models/models.go
@@ -15,7 +15,7 @@ type LazyTest struct {
 }
 
 type LazyTestResult struct {
-	IsSuccess bool
-	Output    string
+	Passed   bool
+	Output   string
 	Duration time.Duration
 }


### PR DESCRIPTION
better name for the `IsSuccess` attribute within the `LazyTestResult` struct