### PR TITLE
engine refactor and rust

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,8 @@ https://github.com/kampanosg/lazytest/blob/c4e9a5800f76c01d780e798e0511b95288de0
 
 LazyTests comes packed with the following engines:
 
-* Golang (requires [`go`](https://go.dev/))
+* Go (requires [`go`](https://go.dev/))
+* Rust (requires [`cargo`](https://www.rust-lang.org/))
 * Bashunit (requires [`bashunit`](https://bashunit.typeddevs.com/))
 
 ## Usage ⚙️

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,8 @@ require (
 	go.uber.org/mock v0.4.0
 )
 
+require github.com/spf13/afero v1.11.0 // indirect
+
 require (
 	github.com/atotto/clipboard v0.1.4
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	go.uber.org/mock v0.4.0
 )
 
-require github.com/spf13/afero v1.11.0 // indirect
+require github.com/spf13/afero v1.11.0
 
 require (
 	github.com/atotto/clipboard v0.1.4

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,8 @@ github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJ
 github.com/rivo/uniseg v0.4.3/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
+github.com/spf13/afero v1.11.0 h1:WJQKhtpdm3v2IzqG8VMqrr6Rf3UYpEF239Jy9wNepM8=
+github.com/spf13/afero v1.11.0/go.mod h1:GH9Y3pIexgf1MTIWtNGyogA5MwRIDXGUr+hbWNoBjkY=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -14,7 +14,7 @@ func NewRunner() *Runner {
 	return &Runner{}
 }
 
-func (r *Runner) Run(cmd string) *models.LazyTestResult {
+func (r *Runner) RunTest(cmd string) *models.LazyTestResult {
 	now := time.Now()
 	c := exec.Command("sh", "-c", cmd)
 	out, err := c.Output()
@@ -24,4 +24,11 @@ func (r *Runner) Run(cmd string) *models.LazyTestResult {
 		Output:   string(out),
 		Duration: time.Since(now),
 	}
+}
+
+func (r *Runner) RunCmd(cmd string) (string, error) {
+	c := exec.Command("sh", "-c", cmd)
+	out, err := c.Output()
+
+	return string(out), err
 }

--- a/internal/tui/elements/tree.go
+++ b/internal/tui/elements/tree.go
@@ -12,7 +12,7 @@ func (e *Elements) initTree() {
 	e.Tree.SetBorderColor(tcell.ColorBlue)
 	e.Tree.SetRoot(e.data.TestTree)
 	e.Tree.SetCurrentNode(e.data.TestTree)
-	e.Tree.SetTopLevel(0)
+	e.Tree.SetTopLevel(1)
 	e.Tree.SetBackgroundColor(tcell.ColorDefault)
 	e.Tree.SetChangedFunc(e.handlers.handleTreeChanged)
 	e.Tree.SetSelectedFunc(func(node *tview.TreeNode) {

--- a/internal/tui/handlers/common.go
+++ b/internal/tui/handlers/common.go
@@ -31,7 +31,7 @@ func runTest(
 		e.Output.SetBorderColor(tcell.ColorYellow)
 	})
 
-	res := r.Run(test.RunCmd)
+	res := r.RunTest(test.RunCmd)
 	ch <- &runResult{
 		node: testNode,
 		res:  res,

--- a/internal/tui/handlers/run.go
+++ b/internal/tui/handlers/run.go
@@ -1,8 +1,6 @@
 package handlers
 
 import (
-	"fmt"
-
 	"github.com/kampanosg/lazytest/internal/tui"
 	"github.com/kampanosg/lazytest/internal/tui/elements"
 	"github.com/kampanosg/lazytest/internal/tui/state"
@@ -24,7 +22,7 @@ func (h *Handlers) HandleRun(r tui.Runner, a tui.Application, e *elements.Elemen
 
 	a.QueueUpdateDraw(func() {
 		e.Output.SetText("")
-		e.InfoBox.SetText(fmt.Sprintf("Running %s", testNode.GetText()))
+		e.InfoBox.SetText("Running...")
 	})
 
 	ch := make(chan *runResult)

--- a/internal/tui/loader/loader.go
+++ b/internal/tui/loader/loader.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/kampanosg/lazytest/pkg/engines"
+	"github.com/kampanosg/lazytest/pkg/models"
 	"github.com/rivo/tview"
 )
 
@@ -17,141 +18,58 @@ func NewLazyTestLoader(e []engines.LazyEngine) *LazyTestLoader {
 	}
 }
 
-func (l *LazyTestLoader) LoadLazyTests(dir string, root *tview.TreeNode) error {
+func (l *LazyTestLoader) LoadLazyTests(dir string) (*tview.TreeNode, error) {
+	root := tview.NewTreeNode(dir)
 	for _, engine := range l.Engines {
 		t, err := engine.Load(dir)
 		if err != nil {
-			return fmt.Errorf("error parsing test suite: %w", err)
+			return nil, fmt.Errorf("error parsing test suite: %w", err)
 		}
 
 		if t == nil || t.Root == nil || len(t.Root.Children) == 0 {
 			continue
 		}
 
-		tuiNodes := toTUINodes(engine, t.Root)
-		root.AddChild(tuiNodes)
+		testNode := toTUINodes(engine, t.Root)
+		root.AddChild(testNode)
 	}
-	return nil
+	return root, nil
 }
 
-// func toTUINodes(engine engines.LazyEngine, lazyNode *models.LazyNode) *tview.TreeNode {
-// 	return doToTUINodes(engine, lazyNode)
-// }
-//
-// func doToTUINodes(engine engines.LazyEngine, lazyNode *models.LazyNode) *tview.TreeNode {
-// 	var node *tview.TreeNode
-//
-// 	if lazyNode.IsDir() {
-// 		hasTests := false
-// 		node = tview.NewTreeNode(fmt.Sprintf("[white]%s", lazyNode.Name))
-//
-// 		for _, child := range lazyNode.Children {
-// 			childNode := doToTUINodes(engine, child)
-//
-// 			if childNode == nil {
-// 				continue
-// 			}
-//
-// 			node.AddChild(childNode)
-// 			hasTests = true
-// 		}
-//
-// 		if hasTests {
-// 			return node
-// 		}
-// 	} else {
-// 		node = tview.NewTreeNode(fmt.Sprintf("[bisque]%s %s", engine.GetIcon(), lazyNode.Name))
-// 		node.SetReference(lazyNode.Ref)
-// 		node.SetSelectable(true)
-//
-// 		for _, t := range lazyNode.Children {
-// 			test := tview.NewTreeNode(fmt.Sprintf("[darkturquoise] %s", t.Name))
-// 			test.SetSelectable(true)
-// 			test.SetReference(t)
-// 			node.AddChild(test)
-// 		}
-// 		return node
-// 	}
-//
-// 	return node
-// }
+func toTUINodes(engine engines.LazyEngine, lazyNode *models.LazyNode) *tview.TreeNode {
+	var node *tview.TreeNode
 
-// func (l *LazyTestLoader) doLoad(dir string, f fs.FileInfo) (*tview.TreeNode, error) {
-// 	var node *tview.TreeNode
-// 	if f.IsDir() {
-// 		children, err := loadFiles(dir)
-// 		if err != nil {
-// 			return nil, err
-// 		}
-//
-// 		hasTests := false
-// 		node = tview.NewTreeNode(fmt.Sprintf("[white]%s", f.Name()))
-//
-// 		for _, child := range children {
-// 			childNode, err := l.doLoad(filepath.Join(dir, child.Name()), child)
-// 			if err != nil {
-// 				return nil, err
-// 			}
-//
-// 			if childNode == nil {
-// 				continue
-// 			}
-//
-// 			node.AddChild(childNode)
-// 			hasTests = true
-// 		}
-//
-// 		if hasTests {
-// 			return node, nil
-// 		}
-// 	} else {
-// 		suite, err := l.findLazyTestSuite(dir)
-// 		if err != nil {
-// 			return nil, fmt.Errorf("error finding lazy test suite: %w", err)
-// 		}
-//
-// 		if suite != nil {
-// 			node = tview.NewTreeNode(fmt.Sprintf("[bisque]%s %s", suite.Icon, f.Name()))
-// 			node.SetReference(suite)
-// 			node.SetSelectable(true)
-//
-// 			for _, t := range suite.Tests {
-// 				test := tview.NewTreeNode(fmt.Sprintf("[darkturquoise] %s", t.Name))
-// 				test.SetSelectable(true)
-// 				test.SetReference(t)
-// 				node.AddChild(test)
-// 			}
-// 			return node, nil
-// 		}
-// 	}
-//
-// 	return nil, nil
-// }
-//
-// // findLazyTestSuite will use the engines to find a test suite in the given path and file
-// func (l *LazyTestLoader) findLazyTestSuite(path string) (*models.LazyTestSuite, error) {
-// 	for _, engine := range l.Engines {
-// 		suite, err := engine.ParseTestSuite(path)
-// 		if err != nil {
-// 			return nil, fmt.Errorf("error parsing test suite: %w", err)
-// 		}
-// 		if suite != nil {
-// 			return suite, nil
-// 		}
-// 	}
-// 	return nil, nil
-// }
-//
-// func loadFiles(dir string) ([]fs.FileInfo, error) {
-// 	file, err := os.Open(filepath.Clean(dir))
-// 	if err != nil {
-// 		return nil, err
-// 	}
-// 	defer file.Close()
-//
-// 	fileInfos, err := file.Readdir(-1)
-// 	if err != nil {
-// 		return nil, fmt.Errorf("error reading directory: %w", err)
-// 	}
-// 	return fileInfos, err
-// }
+	if lazyNode.IsDir() {
+		hasTests := false
+		node = tview.NewTreeNode(fmt.Sprintf("[white]%s", lazyNode.Name))
+
+		for _, child := range lazyNode.Children {
+			childNode := toTUINodes(engine, child)
+
+			if childNode == nil {
+				continue
+			}
+
+			node.AddChild(childNode)
+			hasTests = true
+		}
+
+		if hasTests {
+			return node
+		}
+	} else {
+		node = tview.NewTreeNode(fmt.Sprintf("[bisque]%s %s", engine.GetIcon(), lazyNode.Name))
+		node.SetReference(lazyNode.Ref)
+		node.SetSelectable(true)
+
+		for _, t := range lazyNode.Children {
+			test := tview.NewTreeNode(fmt.Sprintf("[darkturquoise] %s", t.Name))
+			test.SetSelectable(true)
+			test.SetReference(t.Ref)
+			node.AddChild(test)
+		}
+		return node
+	}
+
+	return node
+}

--- a/internal/tui/loader/loader.go
+++ b/internal/tui/loader/loader.go
@@ -2,13 +2,8 @@ package loader
 
 import (
 	"fmt"
-	"io/fs"
-	"os"
-	"path/filepath"
-	"strings"
 
 	"github.com/kampanosg/lazytest/pkg/engines"
-	"github.com/kampanosg/lazytest/pkg/models"
 	"github.com/rivo/tview"
 )
 
@@ -23,109 +18,140 @@ func NewLazyTestLoader(e []engines.LazyEngine) *LazyTestLoader {
 }
 
 func (l *LazyTestLoader) LoadLazyTests(dir string, root *tview.TreeNode) error {
-	fileInfos, err := loadFiles(dir)
-	if err != nil {
-		return err
-	}
-
-	for _, fileInfo := range fileInfos {
-		var node *tview.TreeNode
-
-		if strings.HasPrefix(fileInfo.Name(), ".") {
-			continue
-		}
-
-		node, err = l.doLoad(filepath.Join(dir, fileInfo.Name()), fileInfo)
+	for _, engine := range l.Engines {
+		t, err := engine.Load(dir)
 		if err != nil {
-			return err
+			return fmt.Errorf("error parsing test suite: %w", err)
 		}
 
-		if node == nil {
+		if t == nil || t.Root == nil || len(t.Root.Children) == 0 {
 			continue
 		}
 
-		root.AddChild(node)
-
+		tuiNodes := toTUINodes(engine, t.Root)
+		root.AddChild(tuiNodes)
 	}
 	return nil
 }
 
-func (l *LazyTestLoader) doLoad(dir string, f fs.FileInfo) (*tview.TreeNode, error) {
-	var node *tview.TreeNode
-	if f.IsDir() {
-		children, err := loadFiles(dir)
-		if err != nil {
-			return nil, err
-		}
+// func toTUINodes(engine engines.LazyEngine, lazyNode *models.LazyNode) *tview.TreeNode {
+// 	return doToTUINodes(engine, lazyNode)
+// }
+//
+// func doToTUINodes(engine engines.LazyEngine, lazyNode *models.LazyNode) *tview.TreeNode {
+// 	var node *tview.TreeNode
+//
+// 	if lazyNode.IsDir() {
+// 		hasTests := false
+// 		node = tview.NewTreeNode(fmt.Sprintf("[white]%s", lazyNode.Name))
+//
+// 		for _, child := range lazyNode.Children {
+// 			childNode := doToTUINodes(engine, child)
+//
+// 			if childNode == nil {
+// 				continue
+// 			}
+//
+// 			node.AddChild(childNode)
+// 			hasTests = true
+// 		}
+//
+// 		if hasTests {
+// 			return node
+// 		}
+// 	} else {
+// 		node = tview.NewTreeNode(fmt.Sprintf("[bisque]%s %s", engine.GetIcon(), lazyNode.Name))
+// 		node.SetReference(lazyNode.Ref)
+// 		node.SetSelectable(true)
+//
+// 		for _, t := range lazyNode.Children {
+// 			test := tview.NewTreeNode(fmt.Sprintf("[darkturquoise] %s", t.Name))
+// 			test.SetSelectable(true)
+// 			test.SetReference(t)
+// 			node.AddChild(test)
+// 		}
+// 		return node
+// 	}
+//
+// 	return node
+// }
 
-		hasTests := false
-		node = tview.NewTreeNode(fmt.Sprintf("[white]%s", f.Name()))
-
-		for _, child := range children {
-			childNode, err := l.doLoad(filepath.Join(dir, child.Name()), child)
-			if err != nil {
-				return nil, err
-			}
-
-			if childNode == nil {
-				continue
-			}
-
-			node.AddChild(childNode)
-			hasTests = true
-		}
-
-		if hasTests {
-			return node, nil
-		}
-	} else {
-		suite, err := l.findLazyTestSuite(dir)
-		if err != nil {
-			return nil, fmt.Errorf("error finding lazy test suite: %w", err)
-		}
-
-		if suite != nil {
-			node = tview.NewTreeNode(fmt.Sprintf("[bisque]%s %s", suite.Icon, f.Name()))
-			node.SetReference(suite)
-			node.SetSelectable(true)
-
-			for _, t := range suite.Tests {
-				test := tview.NewTreeNode(fmt.Sprintf("[darkturquoise] %s", t.Name))
-				test.SetSelectable(true)
-				test.SetReference(t)
-				node.AddChild(test)
-			}
-			return node, nil
-		}
-	}
-
-	return nil, nil
-}
-
-// findLazyTestSuite will use the engines to find a test suite in the given path and file
-func (l *LazyTestLoader) findLazyTestSuite(path string) (*models.LazyTestSuite, error) {
-	for _, engine := range l.Engines {
-		suite, err := engine.ParseTestSuite(path)
-		if err != nil {
-			return nil, fmt.Errorf("error parsing test suite: %w", err)
-		}
-		if suite != nil {
-			return suite, nil
-		}
-	}
-	return nil, nil
-}
-
-func loadFiles(dir string) ([]fs.FileInfo, error) {
-	file, err := os.Open(filepath.Clean(dir))
-	if err != nil {
-		return nil, err
-	}
-	defer file.Close()
-
-	fileInfos, err := file.Readdir(-1)
-	if err != nil {
-		return nil, fmt.Errorf("error reading directory: %w", err)
-	}
-	return fileInfos, err
-}
+// func (l *LazyTestLoader) doLoad(dir string, f fs.FileInfo) (*tview.TreeNode, error) {
+// 	var node *tview.TreeNode
+// 	if f.IsDir() {
+// 		children, err := loadFiles(dir)
+// 		if err != nil {
+// 			return nil, err
+// 		}
+//
+// 		hasTests := false
+// 		node = tview.NewTreeNode(fmt.Sprintf("[white]%s", f.Name()))
+//
+// 		for _, child := range children {
+// 			childNode, err := l.doLoad(filepath.Join(dir, child.Name()), child)
+// 			if err != nil {
+// 				return nil, err
+// 			}
+//
+// 			if childNode == nil {
+// 				continue
+// 			}
+//
+// 			node.AddChild(childNode)
+// 			hasTests = true
+// 		}
+//
+// 		if hasTests {
+// 			return node, nil
+// 		}
+// 	} else {
+// 		suite, err := l.findLazyTestSuite(dir)
+// 		if err != nil {
+// 			return nil, fmt.Errorf("error finding lazy test suite: %w", err)
+// 		}
+//
+// 		if suite != nil {
+// 			node = tview.NewTreeNode(fmt.Sprintf("[bisque]%s %s", suite.Icon, f.Name()))
+// 			node.SetReference(suite)
+// 			node.SetSelectable(true)
+//
+// 			for _, t := range suite.Tests {
+// 				test := tview.NewTreeNode(fmt.Sprintf("[darkturquoise] %s", t.Name))
+// 				test.SetSelectable(true)
+// 				test.SetReference(t)
+// 				node.AddChild(test)
+// 			}
+// 			return node, nil
+// 		}
+// 	}
+//
+// 	return nil, nil
+// }
+//
+// // findLazyTestSuite will use the engines to find a test suite in the given path and file
+// func (l *LazyTestLoader) findLazyTestSuite(path string) (*models.LazyTestSuite, error) {
+// 	for _, engine := range l.Engines {
+// 		suite, err := engine.ParseTestSuite(path)
+// 		if err != nil {
+// 			return nil, fmt.Errorf("error parsing test suite: %w", err)
+// 		}
+// 		if suite != nil {
+// 			return suite, nil
+// 		}
+// 	}
+// 	return nil, nil
+// }
+//
+// func loadFiles(dir string) ([]fs.FileInfo, error) {
+// 	file, err := os.Open(filepath.Clean(dir))
+// 	if err != nil {
+// 		return nil, err
+// 	}
+// 	defer file.Close()
+//
+// 	fileInfos, err := file.Readdir(-1)
+// 	if err != nil {
+// 		return nil, fmt.Errorf("error reading directory: %w", err)
+// 	}
+// 	return fileInfos, err
+// }

--- a/internal/tui/mocks/mocks.go
+++ b/internal/tui/mocks/mocks.go
@@ -5,6 +5,7 @@
 //
 //	mockgen -source=tui.go -destination=mocks/mocks.go -package=mocks
 //
+
 // Package mocks is a generated GoMock package.
 package mocks
 
@@ -148,18 +149,18 @@ func (m *MockRunner) EXPECT() *MockRunnerMockRecorder {
 	return m.recorder
 }
 
-// Run mocks base method.
-func (m *MockRunner) Run(command string) *models.LazyTestResult {
+// RunTest mocks base method.
+func (m *MockRunner) RunTest(command string) *models.LazyTestResult {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Run", command)
+	ret := m.ctrl.Call(m, "RunTest", command)
 	ret0, _ := ret[0].(*models.LazyTestResult)
 	return ret0
 }
 
-// Run indicates an expected call of Run.
-func (mr *MockRunnerMockRecorder) Run(command any) *gomock.Call {
+// RunTest indicates an expected call of RunTest.
+func (mr *MockRunnerMockRecorder) RunTest(command any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Run", reflect.TypeOf((*MockRunner)(nil).Run), command)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunTest", reflect.TypeOf((*MockRunner)(nil).RunTest), command)
 }
 
 // MockHandlers is a mock of Handlers interface.

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -90,10 +90,12 @@ func NewTUI(
 }
 
 func (t *TUI) Run() error {
-	t.State.TestTree = tview.NewTreeNode(t.directory)
-	if err := t.loader.LoadLazyTests(t.directory, t.State.TestTree); err != nil {
+	testNode, err := t.loader.LoadLazyTests(t.directory)
+	if err != nil {
 		return fmt.Errorf("unable to load tests, %w", err)
 	}
+
+	t.State.TestTree = testNode
 
 	t.Elements = elements.NewElements()
 	t.Elements.Setup(

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -24,7 +24,7 @@ type Application interface {
 }
 
 type Runner interface {
-	Run(command string) *models.LazyTestResult
+	RunTest(command string) *models.LazyTestResult
 }
 
 type Handlers interface {

--- a/main.go
+++ b/main.go
@@ -3,19 +3,9 @@ package main
 import (
 	"flag"
 	"fmt"
-	"slices"
-	"strings"
 
-	"github.com/kampanosg/lazytest/internal/clipboard"
-	"github.com/kampanosg/lazytest/internal/runner"
-	"github.com/kampanosg/lazytest/internal/tui"
-	"github.com/kampanosg/lazytest/internal/tui/elements"
-	"github.com/kampanosg/lazytest/internal/tui/handlers"
-	"github.com/kampanosg/lazytest/internal/tui/state"
-	"github.com/kampanosg/lazytest/pkg/engines"
-	"github.com/kampanosg/lazytest/pkg/engines/bashunit"
 	"github.com/kampanosg/lazytest/pkg/engines/golang"
-	"github.com/rivo/tview"
+	"github.com/spf13/afero"
 )
 
 const (
@@ -24,7 +14,7 @@ const (
 
 func main() {
 	dir := flag.String("dir", ".", "the directory to start searching for tests")
-	exc := flag.String("excl", "", "engines to exclude")
+	// exc := flag.String("excl", "", "engines to exclude")
 	vsn := flag.Bool("version", false, "the current version of LazyTest")
 	flag.Parse()
 
@@ -33,27 +23,34 @@ func main() {
 		return
 	}
 
-	excludedEngines := strings.Split(*exc, ",")
-	var engines []engines.LazyEngine
-
-	if !slices.Contains(excludedEngines, "golang") {
-		engines = append(engines, golang.NewGolangEngine())
+	g := golang.GolangEngine2{
+		FS: afero.NewOsFs(),
 	}
 
-	if !slices.Contains(excludedEngines, "bashunit") {
-		engines = append(engines, bashunit.NewBashunitEngine())
-	}
+	t, err := g.Vroom(*dir)
+	fmt.Println(t, err)
 
-	a := tview.NewApplication()
-	h := handlers.NewHandlers()
-	r := runner.NewRunner()
-	e := elements.NewElements()
-	c := clipboard.NewClipboardManager()
-	s := state.NewState()
-
-	t := tui.NewTUI(a, h, r, c, e, s, *dir, engines)
-
-	if err := t.Run(); err != nil {
-		panic(err)
-	}
+	// excludedEngines := strings.Split(*exc, ",")
+	// var engines []engines.LazyEngine
+	//
+	// if !slices.Contains(excludedEngines, "golang") {
+	// 	engines = append(engines, golang.NewGolangEngine())
+	// }
+	//
+	// if !slices.Contains(excludedEngines, "bashunit") {
+	// 	engines = append(engines, bashunit.NewBashunitEngine())
+	// }
+	//
+	// a := tview.NewApplication()
+	// h := handlers.NewHandlers()
+	// r := runner.NewRunner()
+	// e := elements.NewElements()
+	// c := clipboard.NewClipboardManager()
+	// s := state.NewState()
+	//
+	// t := tui.NewTUI(a, h, r, c, e, s, *dir, engines)
+	//
+	// if err := t.Run(); err != nil {
+	// 	panic(err)
+	// }
 }

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kampanosg/lazytest/internal/tui/handlers"
 	"github.com/kampanosg/lazytest/internal/tui/state"
 	"github.com/kampanosg/lazytest/pkg/engines"
+	"github.com/kampanosg/lazytest/pkg/engines/bashunit"
 	"github.com/kampanosg/lazytest/pkg/engines/golang"
 	"github.com/rivo/tview"
 	"github.com/spf13/afero"
@@ -33,18 +34,16 @@ func main() {
 		return
 	}
 
-	g := golang.NewGoEngine(afero.NewOsFs())
-
 	excludedEngines := strings.Split(*exc, ",")
 	var engines []engines.LazyEngine
 
 	if !slices.Contains(excludedEngines, "golang") {
-		engines = append(engines, g)
+		engines = append(engines, golang.NewGoEngine(afero.NewOsFs()))
 	}
 
-	// if !slices.Contains(excludedEngines, "bashunit") {
-	// 	engines = append(engines, bashunit.NewBashunitEngine())
-	// }
+	if !slices.Contains(excludedEngines, "bashunit") {
+		engines = append(engines, bashunit.NewBashunitEngine(afero.NewOsFs()))
+	}
 
 	a := tview.NewApplication()
 	h := handlers.NewHandlers()

--- a/main.go
+++ b/main.go
@@ -15,12 +15,13 @@ import (
 	"github.com/kampanosg/lazytest/pkg/engines"
 	"github.com/kampanosg/lazytest/pkg/engines/bashunit"
 	"github.com/kampanosg/lazytest/pkg/engines/golang"
+	"github.com/kampanosg/lazytest/pkg/engines/rust"
 	"github.com/rivo/tview"
 	"github.com/spf13/afero"
 )
 
 const (
-	Version = "v.0.2.0"
+	Version = "v.0.3.0"
 )
 
 func main() {
@@ -34,6 +35,13 @@ func main() {
 		return
 	}
 
+	a := tview.NewApplication()
+	h := handlers.NewHandlers()
+	r := runner.NewRunner()
+	e := elements.NewElements()
+	c := clipboard.NewClipboardManager()
+	s := state.NewState()
+
 	excludedEngines := strings.Split(*exc, ",")
 	var engines []engines.LazyEngine
 
@@ -45,12 +53,9 @@ func main() {
 		engines = append(engines, bashunit.NewBashunitEngine(afero.NewOsFs()))
 	}
 
-	a := tview.NewApplication()
-	h := handlers.NewHandlers()
-	r := runner.NewRunner()
-	e := elements.NewElements()
-	c := clipboard.NewClipboardManager()
-	s := state.NewState()
+	if !slices.Contains(excludedEngines, "rust") {
+		engines = append(engines, rust.NewRustEngine(r))
+	}
 
 	t := tui.NewTUI(a, h, r, c, e, s, *dir, engines)
 

--- a/main.go
+++ b/main.go
@@ -3,8 +3,18 @@ package main
 import (
 	"flag"
 	"fmt"
+	"slices"
+	"strings"
 
+	"github.com/kampanosg/lazytest/internal/clipboard"
+	"github.com/kampanosg/lazytest/internal/runner"
+	"github.com/kampanosg/lazytest/internal/tui"
+	"github.com/kampanosg/lazytest/internal/tui/elements"
+	"github.com/kampanosg/lazytest/internal/tui/handlers"
+	"github.com/kampanosg/lazytest/internal/tui/state"
+	"github.com/kampanosg/lazytest/pkg/engines"
 	"github.com/kampanosg/lazytest/pkg/engines/golang"
+	"github.com/rivo/tview"
 	"github.com/spf13/afero"
 )
 
@@ -14,7 +24,7 @@ const (
 
 func main() {
 	dir := flag.String("dir", ".", "the directory to start searching for tests")
-	// exc := flag.String("excl", "", "engines to exclude")
+	exc := flag.String("excl", "", "engines to exclude")
 	vsn := flag.Bool("version", false, "the current version of LazyTest")
 	flag.Parse()
 
@@ -23,34 +33,29 @@ func main() {
 		return
 	}
 
-	g := golang.GolangEngine2{
-		FS: afero.NewOsFs(),
+	g := golang.NewGoEngine(afero.NewOsFs())
+
+	excludedEngines := strings.Split(*exc, ",")
+	var engines []engines.LazyEngine
+
+	if !slices.Contains(excludedEngines, "golang") {
+		engines = append(engines, g)
 	}
 
-	t, err := g.Vroom(*dir)
-	fmt.Println(t, err)
-
-	// excludedEngines := strings.Split(*exc, ",")
-	// var engines []engines.LazyEngine
-	//
-	// if !slices.Contains(excludedEngines, "golang") {
-	// 	engines = append(engines, golang.NewGolangEngine())
-	// }
-	//
 	// if !slices.Contains(excludedEngines, "bashunit") {
 	// 	engines = append(engines, bashunit.NewBashunitEngine())
 	// }
-	//
-	// a := tview.NewApplication()
-	// h := handlers.NewHandlers()
-	// r := runner.NewRunner()
-	// e := elements.NewElements()
-	// c := clipboard.NewClipboardManager()
-	// s := state.NewState()
-	//
-	// t := tui.NewTUI(a, h, r, c, e, s, *dir, engines)
-	//
-	// if err := t.Run(); err != nil {
-	// 	panic(err)
-	// }
+
+	a := tview.NewApplication()
+	h := handlers.NewHandlers()
+	r := runner.NewRunner()
+	e := elements.NewElements()
+	c := clipboard.NewClipboardManager()
+	s := state.NewState()
+
+	t := tui.NewTUI(a, h, r, c, e, s, *dir, engines)
+
+	if err := t.Run(); err != nil {
+		panic(err)
+	}
 }

--- a/pkg/engines/E.go
+++ b/pkg/engines/E.go
@@ -5,5 +5,6 @@ import (
 )
 
 type LazyEngine interface {
-	ParseTestSuite(fp string) (*models.LazyTestSuite, error)
+	Load(dir string) (*models.LazyTree, error)
+	GetIcon() string
 }

--- a/pkg/engines/bashunit/engine.go
+++ b/pkg/engines/bashunit/engine.go
@@ -59,6 +59,10 @@ func (b *BashEngine) Load(dir string) (*models.LazyTree, error) {
 		root.AddChild(node)
 	}
 
+	if len(root.Children) == 0 {
+		return nil, nil
+	}
+
 	return models.NewLazyTree(root), nil
 }
 
@@ -142,7 +146,7 @@ func (b *BashEngine) parseTestSuite(fp string) (*models.LazyTestSuite, error) {
 
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
-		line := scanner.Text()
+		line := strings.TrimSpace(scanner.Text())
 		if strings.HasPrefix(line, "function test_") {
 			name := strings.Fields(line)[1]
 			name = strings.TrimSuffix(name, "()")

--- a/pkg/engines/bashunit/engine.go
+++ b/pkg/engines/bashunit/engine.go
@@ -13,9 +13,8 @@ import (
 )
 
 const (
-	suiteType = "bashunit"
-	suffix    = ".sh"
-	icon      = "󱆃"
+	suffix = ".sh"
+	icon   = "󱆃"
 )
 
 type FileSystem interface {
@@ -140,7 +139,6 @@ func (b *BashEngine) parseTestSuite(fp string) (*models.LazyTestSuite, error) {
 
 	suite := &models.LazyTestSuite{
 		Path: fp,
-		Icon: icon,
 	}
 
 	scanner := bufio.NewScanner(file)

--- a/pkg/engines/bashunit/engine.go
+++ b/pkg/engines/bashunit/engine.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"fmt"
 	"io/fs"
-	"os"
 	"path/filepath"
 	"strings"
 
@@ -22,10 +21,10 @@ type FileSystem interface {
 }
 
 type BashEngine struct {
-	FS FileSystem
+	FS afero.Fs
 }
 
-func NewBashunitEngine(fs FileSystem) *BashEngine {
+func NewBashunitEngine(fs afero.Fs) *BashEngine {
 	return &BashEngine{
 		FS: fs,
 	}
@@ -64,7 +63,7 @@ func (b *BashEngine) Load(dir string) (*models.LazyTree, error) {
 }
 
 func (b *BashEngine) loadFiles(path string) ([]fs.FileInfo, error) {
-	dir, err := os.Open(filepath.Clean(path))
+	dir, err := b.FS.Open(filepath.Clean(path))
 	if err != nil {
 		return nil, err
 	}
@@ -131,7 +130,7 @@ func (b *BashEngine) parseTestSuite(fp string) (*models.LazyTestSuite, error) {
 		return nil, nil
 	}
 
-	file, err := os.Open(filepath.Clean(fp))
+	file, err := b.FS.Open(filepath.Clean(fp))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/engines/bashunit/engine_test.go
+++ b/pkg/engines/bashunit/engine_test.go
@@ -33,38 +33,38 @@ func TestBashEngine_Load(t *testing.T) {
 		wantNil bool
 		want    *models.LazyTree
 	}{
-		// {
-		// 	name: "no files",
-		// 	fields: func() fields {
-		// 		appFS := afero.NewMemMapFs()
-		// 		return fields{
-		// 			fs: appFS,
-		// 		}
-		// 	},
-		// 	args: args{
-		// 		dir: "/",
-		// 	},
-		// 	wantErr: false,
-		// 	wantNil: true,
-		// 	want:    nil,
-		// },
-		// {
-		// 	name: "no tests",
-		// 	fields: func() fields {
-		// 		appFS := afero.NewMemMapFs()
-		// 		appFS.MkdirAll("src", 0755)
-		// 		afero.WriteFile(appFS, "src/test.sh", []byte("#!/bin/bash\necho 'hello'"), 0644)
-		// 		return fields{
-		// 			fs: appFS,
-		// 		}
-		// 	},
-		// 	args: args{
-		// 		dir: "src",
-		// 	},
-		// 	wantErr: false,
-		// 	wantNil: true,
-		// 	want:    nil,
-		// },
+		{
+			name: "no files",
+			fields: func() fields {
+				appFS := afero.NewMemMapFs()
+				return fields{
+					fs: appFS,
+				}
+			},
+			args: args{
+				dir: "/",
+			},
+			wantErr: false,
+			wantNil: true,
+			want:    nil,
+		},
+		{
+			name: "no tests",
+			fields: func() fields {
+				appFS := afero.NewMemMapFs()
+				appFS.MkdirAll("src", 0755)
+				afero.WriteFile(appFS, "src/test.sh", []byte("#!/bin/bash\necho 'hello'"), 0644)
+				return fields{
+					fs: appFS,
+				}
+			},
+			args: args{
+				dir: "src",
+			},
+			wantErr: false,
+			wantNil: true,
+			want:    nil,
+		},
 		{
 			name: "with tests",
 			fields: func() fields {
@@ -89,9 +89,6 @@ func TestBashEngine_Load(t *testing.T) {
 							Children: []*models.LazyNode{
 								{
 									Name: "test",
-									Ref: &models.LazyTest{
-										Name: "test",
-									},
 								},
 							},
 						},

--- a/pkg/engines/bashunit/engine_test.go
+++ b/pkg/engines/bashunit/engine_test.go
@@ -1,0 +1,125 @@
+package bashunit
+
+import (
+	"testing"
+
+	"github.com/kampanosg/lazytest/pkg/models"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBashEngine_GetIcon(t *testing.T) {
+	b := NewBashunitEngine(nil)
+	icon := b.GetIcon()
+	if icon != "󱆃" {
+		t.Errorf("Expected icon to be '󱆃', but got %s", icon)
+	}
+}
+
+func TestBashEngine_Load(t *testing.T) {
+	type fields struct {
+		fs afero.Fs
+	}
+
+	type args struct {
+		dir string
+	}
+
+	tests := []struct {
+		name    string
+		fields  func() fields
+		args    args
+		wantErr bool
+		wantNil bool
+		want    *models.LazyTree
+	}{
+		// {
+		// 	name: "no files",
+		// 	fields: func() fields {
+		// 		appFS := afero.NewMemMapFs()
+		// 		return fields{
+		// 			fs: appFS,
+		// 		}
+		// 	},
+		// 	args: args{
+		// 		dir: "/",
+		// 	},
+		// 	wantErr: false,
+		// 	wantNil: true,
+		// 	want:    nil,
+		// },
+		// {
+		// 	name: "no tests",
+		// 	fields: func() fields {
+		// 		appFS := afero.NewMemMapFs()
+		// 		appFS.MkdirAll("src", 0755)
+		// 		afero.WriteFile(appFS, "src/test.sh", []byte("#!/bin/bash\necho 'hello'"), 0644)
+		// 		return fields{
+		// 			fs: appFS,
+		// 		}
+		// 	},
+		// 	args: args{
+		// 		dir: "src",
+		// 	},
+		// 	wantErr: false,
+		// 	wantNil: true,
+		// 	want:    nil,
+		// },
+		{
+			name: "with tests",
+			fields: func() fields {
+				appFS := afero.NewMemMapFs()
+				appFS.MkdirAll("src", 0755)
+				afero.WriteFile(appFS, "src/test.sh", []byte("#!/bin/bash \n\n function test_echo() { \n echo 1 \n }"), 0644)
+				return fields{
+					fs: appFS,
+				}
+			},
+			args: args{
+				dir: "src",
+			},
+			wantErr: false,
+			wantNil: false,
+			want: &models.LazyTree{
+				Root: &models.LazyNode{
+					Name: "src",
+					Children: []*models.LazyNode{
+						{
+							Name: "test.sh",
+							Children: []*models.LazyNode{
+								{
+									Name: "test",
+									Ref: &models.LazyTest{
+										Name: "test",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := tt.fields()
+			b := NewBashunitEngine(f.fs)
+			got, err := b.Load(tt.args.dir)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
+			if tt.wantNil {
+				assert.Nil(t, got)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.NotNil(t, got)
+			assert.Equal(t, len(tt.want.Root.Children), len(got.Root.Children))
+		})
+	}
+}

--- a/pkg/engines/golang/engine.go
+++ b/pkg/engines/golang/engine.go
@@ -89,7 +89,7 @@ func (g *GoEngine) doLoad(dir string, f fs.FileInfo) (*models.LazyNode, error) {
 		for _, child := range children {
 			childNode, err := g.doLoad(filepath.Join(dir, child.Name()), child)
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("error loading child: %w", err)
 			}
 
 			if childNode == nil {

--- a/pkg/engines/golang/engine.go
+++ b/pkg/engines/golang/engine.go
@@ -36,7 +36,7 @@ func NewGoEngine(fs FileSystem) *GoEngine {
 }
 
 func (g *GoEngine) GetIcon() string {
-	return "󰟓"
+	return icon
 }
 
 func (g *GoEngine) Load(dir string) (*models.LazyTree, error) {
@@ -151,7 +151,6 @@ func (g *GoEngine) parseTestSuite(fp string) (*models.LazyTestSuite, error) {
 
 	suite := &models.LazyTestSuite{
 		Path: fp,
-		Type: suiteType,
 		Icon: icon,
 	}
 

--- a/pkg/engines/golang/engine.go
+++ b/pkg/engines/golang/engine.go
@@ -16,9 +16,8 @@ import (
 )
 
 const (
-	suffix    = "_test.go"
-	suiteType = "golang"
-	icon      = "󰟓"
+	suffix = "_test.go"
+	icon   = "󰟓"
 )
 
 type FileSystem interface {
@@ -151,7 +150,6 @@ func (g *GoEngine) parseTestSuite(fp string) (*models.LazyTestSuite, error) {
 
 	suite := &models.LazyTestSuite{
 		Path: fp,
-		Icon: icon,
 	}
 
 	for _, f := range node.Decls {

--- a/pkg/engines/golang/engine_test.go
+++ b/pkg/engines/golang/engine_test.go
@@ -1,0 +1,130 @@
+package golang
+
+import (
+	"testing"
+
+	"github.com/kampanosg/lazytest/pkg/models"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_GetIcon(t *testing.T) {
+	g := NewGoEngine(nil)
+	icon := g.GetIcon()
+	if icon != "󰟓" {
+		t.Errorf("Expected icon to be '󰟓', but got %s", icon)
+	}
+}
+
+func Test_Load(t *testing.T) {
+	type fields struct {
+		fs afero.Fs
+	}
+
+	type args struct {
+		dir string
+	}
+
+	tests := []struct {
+		name    string
+		fields  func() fields
+		args    args
+		wantErr bool
+		wantNil bool
+		want    *models.LazyTree
+	}{
+		{
+			name: "no go.mod file",
+			fields: func() fields {
+				appFS := afero.NewMemMapFs()
+				appFS.MkdirAll("src", 0755)
+				afero.WriteFile(appFS, "src/main.go", []byte("package main"), 0644)
+				return fields{
+					fs: appFS,
+				}
+			},
+			args: args{
+				dir: "/",
+			},
+			wantErr: false,
+			wantNil: true,
+			want:    nil,
+		},
+		{
+			name: "no tests",
+			fields: func() fields {
+				appFS := afero.NewMemMapFs()
+				appFS.MkdirAll("src", 0755)
+				afero.WriteFile(appFS, "src/go.mod", []byte("module test"), 0644)
+				afero.WriteFile(appFS, "src/main.go", []byte("package main"), 0644)
+				return fields{
+					fs: appFS,
+				}
+			},
+			args: args{
+				dir: "/",
+			},
+			wantErr: false,
+			wantNil: true,
+			want:    nil,
+		},
+		{
+			name: "load tests",
+			fields: func() fields {
+				appFS := afero.NewMemMapFs()
+				appFS.MkdirAll("src", 0755)
+				afero.WriteFile(appFS, "src/go.mod", []byte("module test"), 0644)
+				afero.WriteFile(appFS, "src/main.go", []byte("package main"), 0644)
+				afero.WriteFile(appFS, "src/main_test.go", []byte("package main \n\n func TestMain(t *testing.T){t.skip()}"), 0644)
+				return fields{
+					fs: appFS,
+				}
+			},
+			args: args{
+				dir: "src",
+			},
+			wantErr: false,
+			wantNil: false,
+			want: &models.LazyTree{
+				Root: &models.LazyNode{
+					Name: "src",
+					Children: []*models.LazyNode{
+						{
+							Name:     "main_test.go",
+							Children: []*models.LazyNode{
+								{
+									Name: "TestMain",
+									Children: nil,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fields := tt.fields()
+			g := NewGoEngine(fields.fs)
+
+			got, err := g.Load(tt.args.dir)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+
+			if tt.wantNil {
+				assert.Nil(t, got)
+				return
+			}
+
+			assert.NotNil(t, got)
+			assert.Equal(t, len(tt.want.Root.Children), len(got.Root.Children))
+		})
+	}
+
+}

--- a/pkg/engines/golang/engine_test.go
+++ b/pkg/engines/golang/engine_test.go
@@ -90,11 +90,10 @@ func Test_Load(t *testing.T) {
 					Name: "src",
 					Children: []*models.LazyNode{
 						{
-							Name:     "main_test.go",
+							Name: "main_test.go",
 							Children: []*models.LazyNode{
 								{
 									Name: "TestMain",
-									Children: nil,
 								},
 							},
 						},

--- a/pkg/engines/rust/engine.go
+++ b/pkg/engines/rust/engine.go
@@ -102,6 +102,10 @@ func (r *RustEngine) Load(dir string) (*models.LazyTree, error) {
 		}
 	}
 
+	if len(root.Children) == 0 {
+		return nil, nil
+	}
+
 	lazyRoot := toLazyTree(root)
 	return models.NewLazyTree(lazyRoot), nil
 }

--- a/pkg/engines/rust/engine.go
+++ b/pkg/engines/rust/engine.go
@@ -1,0 +1,120 @@
+package rust
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/kampanosg/lazytest/pkg/models"
+)
+
+const (
+	suffix = ".rs"
+	icon   = ""
+)
+
+type Runner interface {
+	RunCmd(cmd string) (string, error)
+}
+
+type RustEngine struct {
+	Runner Runner
+}
+
+type rustNode struct {
+	Name     string
+	Ref      any
+	Children map[string]*rustNode
+}
+
+func NewRustEngine(r Runner) *RustEngine {
+	return &RustEngine{
+		Runner: r,
+	}
+}
+
+func (r *RustEngine) GetIcon() string {
+	return icon
+}
+
+func (r *RustEngine) Load(dir string) (*models.LazyTree, error) {
+	o, err := r.Runner.RunCmd("cargo test -- --list --format=terse")
+	if err != nil {
+		return nil, fmt.Errorf("error listing tests: %w", err)
+	}
+
+	root := &rustNode{
+		Name:     dir,
+		Ref:      nil,
+		Children: make(map[string]*rustNode),
+	}
+
+	lines := strings.Split(o, "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+
+		parts := strings.Split(line, ": test")
+		if len(parts) != 2 {
+			continue
+		}
+
+		testLine := parts[0]
+		testParts := strings.Split(testLine, "::")
+
+		currentNode := root
+
+		var testSuite *models.LazyTestSuite
+
+		for i, part := range testParts {
+			part = strings.TrimSpace(part)
+			childNode, exists := currentNode.Children[part]
+			if !exists {
+				childNode = &rustNode{
+					Name:     part,
+					Children: make(map[string]*rustNode),
+				}
+
+				if i == len(testParts)-2 {
+					suite := &models.LazyTestSuite{
+						Path:  strings.Join(testParts[:i+1], "::"),
+						Tests: make([]*models.LazyTest, 0),
+					}
+					childNode.Ref = suite
+				}
+				currentNode.Children[part] = childNode
+			}
+			currentNode = childNode
+
+			if i == len(testParts)-2 {
+				testSuite = currentNode.Ref.(*models.LazyTestSuite)
+			}
+
+			if i == len(testParts)-1 {
+				test := &models.LazyTest{
+					Name: part,
+					RunCmd: fmt.Sprintf("cargo t %s -- --exact", testLine),
+				}
+				childNode.Ref = test
+				testSuite.Tests = append(testSuite.Tests, test)
+			}
+		}
+	}
+
+	lazyRoot := toLazyTree(root)
+	return models.NewLazyTree(lazyRoot), nil
+}
+
+func toLazyTree(r *rustNode) *models.LazyNode {
+	children := make([]*models.LazyNode, 0)
+	for _, child := range r.Children {
+		children = append(children, toLazyTree(child))
+	}
+
+	return &models.LazyNode{
+		Name:     r.Name,
+		Ref:      r.Ref,
+		Children: children,
+	}
+}

--- a/pkg/engines/rust/engine.go
+++ b/pkg/engines/rust/engine.go
@@ -39,7 +39,7 @@ func (r *RustEngine) GetIcon() string {
 func (r *RustEngine) Load(dir string) (*models.LazyTree, error) {
 	o, err := r.Runner.RunCmd("cargo test -- --list --format=terse")
 	if err != nil {
-		return nil, fmt.Errorf("error listing tests: %w", err)
+		return nil, nil
 	}
 
 	root := &rustNode{

--- a/pkg/engines/rust/engine_test.go
+++ b/pkg/engines/rust/engine_test.go
@@ -1,0 +1,124 @@
+package rust
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/kampanosg/lazytest/pkg/models"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockRunner struct {
+	runHandler func(cmd string) (string, error)
+}
+
+func (m *mockRunner) RunCmd(cmd string) (string, error) {
+	return m.runHandler(cmd)
+}
+
+func TestRustEngine_GetIcon(t *testing.T) {
+	g := NewRustEngine(nil)
+	icon := g.GetIcon()
+	if icon != "" {
+		t.Errorf("Expected icon to be '', but got %s", icon)
+	}
+}
+
+func TestRustEngine_Load(t *testing.T) {
+	type fields struct {
+		runner *mockRunner
+	}
+
+	type args struct {
+		dir string
+	}
+
+	tests := []struct {
+		name    string
+		fields  func() fields
+		args    args
+		wantErr bool
+		wantNil bool
+		want    *models.LazyTree
+	}{
+		{
+			name: "runner returns error",
+			fields: func() fields {
+				return fields{
+					runner: &mockRunner{
+						runHandler: func(cmd string) (string, error) {
+							return "", errors.New("an error")
+						},
+					},
+				}
+			},
+			args: args{
+				dir: ".",
+			},
+			wantErr: false,
+			wantNil: true,
+			want:    nil,
+		},
+		{
+			name: "no tests in the project",
+			fields: func() fields {
+				return fields{
+					runner: &mockRunner{
+						runHandler: func(cmd string) (string, error) {
+							return "no tests to parse", nil
+						},
+					},
+				}
+			},
+			args: args{
+				dir: ".",
+			},
+			wantErr: false,
+			wantNil: true,
+			want:    nil,
+		},
+		{
+			name: "parse tests",
+			fields: func() fields {
+				return fields{
+					runner: &mockRunner{
+						runHandler: func(cmd string) (string, error) {
+							return `
+							
+							`, nil
+						},
+					},
+				}
+			},
+			args: args{
+				dir: ".",
+			},
+			wantErr: false,
+			wantNil: true,
+			want:    nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fields := tt.fields()
+			g := NewRustEngine(fields.runner)
+
+			got, err := g.Load(tt.args.dir)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+
+			if tt.wantNil {
+				assert.Nil(t, got)
+				return
+			}
+
+			assert.Equal(t, len(tt.want.Root.Children), len(got.Root.Children))
+		})
+	}
+
+}

--- a/pkg/engines/rust/engine_test.go
+++ b/pkg/engines/rust/engine_test.go
@@ -84,8 +84,23 @@ func TestRustEngine_Load(t *testing.T) {
 					runner: &mockRunner{
 						runHandler: func(cmd string) (string, error) {
 							return `
-							
-							`, nil
+Finished test [unoptimized + debuginfo] target(s) in 0.66s
+     Running unittests src/lib.rs (target/debug/deps/wallet_api-93c222fb9d897c74)
+api::account_handlers::tests::test_post_accounts_existing_account: test
+api::account_handlers::tests::test_post_accounts_no_account: test
+api::account_handlers::tests::test_post_accounts_no_account_with_generate_ephemeral_attr: test
+api::account_handlers::tests::test_post_accounts_no_account_without_generate_ephemeral_attr: test
+api::error::tests::test_error_handler_bad_request: test
+api::error::tests::test_error_handler_bad_request_validation: test
+api::error::tests::test_error_handler_unauthorised: test
+api::item_handlers::tests::test_delete_item: test
+api::item_handlers::tests::test_get_items: test
+api::item_handlers::tests::test_identity_failure: test
+api::item_handlers::tests::test_patch_item: test
+api::item_handlers::tests::test_post_inital_item: test
+models::wallet::tests::test_card_brand_from_str: test
+     Running unittests src/main.rs (target/debug/deps/wallet_api-67ae81328fc5acea)
+   Doc-tests wallet-api`, nil
 						},
 					},
 				}
@@ -94,8 +109,20 @@ func TestRustEngine_Load(t *testing.T) {
 				dir: ".",
 			},
 			wantErr: false,
-			wantNil: true,
-			want:    nil,
+			wantNil: false,
+			want: &models.LazyTree{
+				Root: &models.LazyNode{
+					Name: "wallet_api",
+					Children: []*models.LazyNode{
+						{
+							Name: "api",
+						},
+						{
+							Name: "models",
+						},
+					},
+				},
+			},
 		},
 	}
 

--- a/pkg/models/models.go
+++ b/pkg/models/models.go
@@ -4,7 +4,6 @@ import "time"
 
 type LazyTestSuite struct {
 	Tests []*LazyTest
-	Type  string
 	Path  string
 	Icon  string
 }

--- a/pkg/models/models.go
+++ b/pkg/models/models.go
@@ -5,7 +5,6 @@ import "time"
 type LazyTestSuite struct {
 	Tests []*LazyTest
 	Path  string
-	Icon  string
 }
 
 type LazyTest struct {

--- a/pkg/models/tree.go
+++ b/pkg/models/tree.go
@@ -1,7 +1,5 @@
 package models
 
-import "fmt"
-
 type LazyTree struct {
 	Root *LazyNode
 }
@@ -30,9 +28,7 @@ func (n *LazyNode) AddChild(node *LazyNode) {
 }
 
 func (n *LazyNode) SetReference(ref any) {
-	if n.Ref == nil {
-		n.Ref = ref
-	}
+	n.Ref = ref
 }
 
 func (n *LazyNode) IsTest() bool {
@@ -55,10 +51,4 @@ func (n *LazyNode) IsTestSuite() bool {
 
 func (n *LazyNode) IsDir() bool {
 	return !n.IsTest() && !n.IsTestSuite()
-}
-func (n *LazyNode) PrintDepthFirst() {
-	fmt.Println(n.Name)
-	for _, child := range n.Children {
-		child.PrintDepthFirst()
-	}
 }

--- a/pkg/models/tree.go
+++ b/pkg/models/tree.go
@@ -6,7 +6,6 @@ type LazyTree struct {
 
 type LazyNode struct {
 	Name     string
-	Path     string
 	Ref      any
 	Children []*LazyNode
 }
@@ -17,10 +16,9 @@ func NewLazyTree(root *LazyNode) *LazyTree {
 	}
 }
 
-func NewLazyNode(name, path string, ref any) *LazyNode {
+func NewLazyNode(name string, ref any) *LazyNode {
 	return &LazyNode{
 		Name: name,
-		Path: path,
 		Ref:  ref,
 	}
 }
@@ -53,4 +51,8 @@ func (n *LazyNode) IsTestSuite() bool {
 
 	_, ok := n.Ref.(*LazyTestSuite)
 	return ok
+}
+
+func (n *LazyNode) IsDir() bool {
+	return !n.IsTest() && !n.IsTestSuite()
 }

--- a/pkg/models/tree.go
+++ b/pkg/models/tree.go
@@ -1,0 +1,56 @@
+package models
+
+type LazyTree struct {
+	Root *LazyNode
+}
+
+type LazyNode struct {
+	Name     string
+	Path     string
+	Ref      any
+	Children []*LazyNode
+}
+
+func NewLazyTree(root *LazyNode) *LazyTree {
+	return &LazyTree{
+		Root: root,
+	}
+}
+
+func NewLazyNode(name, path string, ref any) *LazyNode {
+	return &LazyNode{
+		Name: name,
+		Path: path,
+		Ref:  ref,
+	}
+}
+
+func (n *LazyNode) AddChild(node *LazyNode) {
+	if n.Children == nil {
+		n.Children = append(n.Children, node)
+	}
+}
+
+func (n *LazyNode) SetReference(ref any) {
+	if n.Ref == nil {
+		n.Ref = ref
+	}
+}
+
+func (n *LazyNode) IsTest() bool {
+	if n.Ref == nil {
+		return false
+	}
+
+	_, ok := n.Ref.(*LazyTest)
+	return ok
+}
+
+func (n *LazyNode) IsTestSuite() bool {
+	if n.Ref == nil {
+		return false
+	}
+
+	_, ok := n.Ref.(*LazyTestSuite)
+	return ok
+}

--- a/pkg/models/tree.go
+++ b/pkg/models/tree.go
@@ -27,6 +27,16 @@ func (n *LazyNode) AddChild(node *LazyNode) {
 	n.Children = append(n.Children, node)
 }
 
+func (n *LazyNode) FindChild(name string) *LazyNode {
+	for _, child := range n.Children {
+		if child.Name == name {
+			return child
+		}
+	}
+
+	return nil
+}
+
 func (n *LazyNode) SetReference(ref any) {
 	n.Ref = ref
 }

--- a/pkg/models/tree.go
+++ b/pkg/models/tree.go
@@ -1,5 +1,7 @@
 package models
 
+import "fmt"
+
 type LazyTree struct {
 	Root *LazyNode
 }
@@ -24,9 +26,7 @@ func NewLazyNode(name string, ref any) *LazyNode {
 }
 
 func (n *LazyNode) AddChild(node *LazyNode) {
-	if n.Children == nil {
-		n.Children = append(n.Children, node)
-	}
+	n.Children = append(n.Children, node)
 }
 
 func (n *LazyNode) SetReference(ref any) {
@@ -55,4 +55,10 @@ func (n *LazyNode) IsTestSuite() bool {
 
 func (n *LazyNode) IsDir() bool {
 	return !n.IsTest() && !n.IsTestSuite()
+}
+func (n *LazyNode) PrintDepthFirst() {
+	fmt.Println(n.Name)
+	for _, child := range n.Children {
+		child.PrintDepthFirst()
+	}
 }

--- a/pkg/models/tree_test.go
+++ b/pkg/models/tree_test.go
@@ -1,0 +1,176 @@
+package models
+
+import "testing"
+
+func TestAddChild(t *testing.T) {
+	tests := []struct {
+		name string
+		node *LazyNode
+		want int
+	}{
+		{
+			name: "success",
+			node: &LazyNode{
+				Name: "root",
+			},
+			want: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			child := &LazyNode{
+				Name: "child",
+			}
+			tt.node.AddChild(child)
+			if len(tt.node.Children) != tt.want {
+				t.Errorf("AddChild() got = %d, want %d", len(tt.node.Children), tt.want)
+			}
+		})
+	}
+}
+
+func TestSetReference(t *testing.T) {
+	tests := []struct {
+		name string
+		node *LazyNode
+		want any
+	}{
+		{
+			name: "success",
+			node: &LazyNode{
+				Name: "root",
+			},
+			want: "reference",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.node.SetReference(tt.want)
+			if tt.node.Ref != tt.want {
+				t.Errorf("SetReference() got = %v, want %v", tt.node.Ref, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsTest(t *testing.T) {
+	tests := []struct {
+		name string
+		node *LazyNode
+		want bool
+	}{
+		{
+			name: "success",
+			node: &LazyNode{
+				Name: "root",
+				Ref:  &LazyTest{},
+			},
+			want: true,
+		},
+		{
+			name: "nil ref",
+			node: &LazyNode{
+				Name: "root",
+			},
+			want: false,
+		},
+		{
+			name: "not a test",
+			node: &LazyNode{
+				Name: "root",
+				Ref:  "not a test",
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.node.IsTest(); got != tt.want {
+				t.Errorf("IsTest() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsTestSuite(t *testing.T) {
+	tests := []struct {
+		name string
+		node *LazyNode
+		want bool
+	}{
+		{
+			name: "success",
+			node: &LazyNode{
+				Name: "root",
+				Ref:  &LazyTestSuite{},
+			},
+			want: true,
+		},
+		{
+			name: "nil ref",
+			node: &LazyNode{
+				Name: "root",
+			},
+			want: false,
+		},
+		{
+			name: "not a test suite",
+			node: &LazyNode{
+				Name: "root",
+				Ref:  "not a test suite",
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.node.IsTestSuite(); got != tt.want {
+				t.Errorf("IsTestSuite() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsDir(t *testing.T) {
+	tests := []struct {
+		name string
+		node *LazyNode
+		want bool
+	}{
+		{
+			name: "success",
+			node: &LazyNode{
+				Name: "root",
+			},
+			want: true,
+		},
+		{
+			name: "test",
+			node: &LazyNode{
+				Name: "root",
+				Ref:  &LazyTest{},
+			},
+			want: false,
+		},
+		{
+			name: "test suite",
+			node: &LazyNode{
+				Name: "root",
+				Ref:  &LazyTestSuite{},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.node.IsDir(); got != tt.want {
+				t.Errorf("IsDir() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
this pr introduces a major refactor of the EngineAPI™️. instead of passing a single file and determining if there are tests, engines now parse the entire working directory and return a `LazyTree` result. in turn the TUI (or whatever client) should parse that tree.

the `Engine` interface has also changed to the following

```go
type Engine interface {
  GetIcon() string
  Load(dir string) (*models.LazyTree, error)
}
``` 

now, tools such as `cargo` or LSPs can be used to build the results, instead of relying on manual processing such as `grep` and regular expressions. this should hopefully make the tool more reliable. at the same time, engines are now a lot easier to test. 

however, this adds more CPU cycles which can cause slower startups. this is because the engine builds a `LazyTree` and the client (e.g. the TUI) has to iterate the tree to build its own structure. therefore, startup _could_ be a bit slower - but from anecdotal evidence on my machine, I haven't seen any differences.

there's always room for improvement as there's quite a lot of duplicated code between engines but I think that this is a better approach